### PR TITLE
adds dependabot for maintaining the image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "docker" # to check versions used in Dockerfile
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  - package-ecosystem: "github-actions" # to check versions of github actions we use
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Adds dependabot to manage the Dockerfile base image. Should ignore major and minor updates since the next major/minor version involves Kafka changes