### PR TITLE
update pod resources and add tls certs def to match platform-mq

### DIFF
--- a/deploy/kafkaconnect-w-auth.yml
+++ b/deploy/kafkaconnect-w-auth.yml
@@ -181,6 +181,8 @@ objects:
     name: kessel-kafka-connect
   spec:
     bootstrapServers: ${BOOTSTRAP_SERVERS}
+    tls:
+      trustedCertificates: []
     authentication:
       type: scram-sha-512
       username: ${KAFKA_USERNAME}
@@ -208,11 +210,11 @@ objects:
     replicas: ${{CONNECT_REPLICAS}}
     resources:
       limits:
+        cpu: 1
+        memory: 2Gi
+      requests:
         cpu: 500m
         memory: 1Gi
-      requests:
-        cpu: 250m
-        memory: 512Mi
     template:
       pod:
         imagePullSecrets:


### PR DESCRIPTION
* Updates pod resources as current pod is getting OOMKilled (matches platform-mq)
* Also adds TLS section to ensure it uses TLS as i think its required (even though there is no certs provided, they are already trusted by nodes)

https://github.com/RedHatInsights/platform-mq/blob/master/deploys/openshift/kafka-connect-with-auth.yaml for reference