### PR TITLE
updates debezium to 3.1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ USER root:root
 # Update the debezium maven and release versions to update Debezium and related plugins
 ENV KAFKA_CONNECT_PLUGINS_DIR=/opt/kafka/plugins \
     EXTERNAL_LIBS_DIR=/opt/kafka/libs \
-    DEBEZIUM_MAVEN_VERSION=2.7.3.Final \
-    DEBEZIUM_RELEASE_VERSION=2.7
+    DEBEZIUM_MAVEN_VERSION=3.1.3.Final \
+    DEBEZIUM_RELEASE_VERSION=3.1
 
 RUN rm -rf /opt/kafka-exporter
 


### PR DESCRIPTION
* updates debezium to 3.1.3

Validation in Ephemeral using HBI Migration Process

```shell
$ oc get kc kessel-kafka-connect 
NAME                   DESIRED REPLICAS   READY
kessel-kafka-connect   1                  True

$ oc get kctr | grep hbi
hbi-migration-connector             kessel-kafka-connect   io.debezium.connector.postgresql.PostgresConnector               1           True
hbi-outbox-connector                kessel-kafka-connect   io.debezium.connector.postgresql.PostgresConnector               1           True

$ oc describe kc kessel-kafka-connect | grep debezium -A 3
    Class:              io.debezium.connector.postgresql.PostgresConnector
    Type:               source
    Version:            3.1.3.Final
    Class:              org.apache.kafka.connect.mirror.MirrorCheckpointConnector

$ oc rsh host-inventory-db-687bd8c9df-rvh48 psql -h localhost -d host-inventory -c "select count(*) from hbi.hosts;"
 count 
-------
  1000
(1 row)

# KIC Logs showing all replication completed
INFO ts=2025-08-04T14:55:01Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=response: 
INFO ts=2025-08-04T14:55:01Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=consumed event from topic host-inventory.hbi.hosts, partition 0 at offset 999

# Inventory DB matches count of HBI
$ oc rsh kessel-inventory-db-f86fbb654-tll6m psql -h localhost -d kessel-inventory -c "select count(*) from resources;"
 count 
-------
  1000
(1 row)

# validates replication to relations via token count
 select count(*) from resources where consistency_token IS NOT NULL and consistency_token <> '';                                              
 count 
-------
  1000
(1 row)
```
