### PR TITLE
RHCLOUD-41797: add hbi connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ make build-push-minimal
 ```
 
 ### Kafka Connect Deployment
-The KafkaConnect CR templates can be used to deploy a Kafka Connect cluster using the image built with the provided Dockerfile. The template is designed to allow for multiple service providers to use the same template while avoiding name duplication as these Connect clusters will likely live in the same namespace
+The KafkaConnect CR templates can be used to deploy a Kafka Connect cluster using the image built with the provided Dockerfile. There are 3 versions of the KafkaConnect CR: one with authentication, one without, and one for FedRAMP
 
-There are 2 versions of the KafkaConnect CR: one with authentication, one without
+The `kafkaconnect-no-auth.yml` template is useful for Ephemeral testing, where the Clowder-provided Kafka cluster can be used for the Connect cluster and does not require any authentication. In ephemeral, by default Kessel Inventory API ships with Kessel Kafka Connect and can be deployed that way.
 
-The `kafkaconnect-no-auth.yml` template is useful for Ephemeral, where the Clowder-provided Kafka cluster can be used for the Connect cluster and does not require any authentication.
+The `kafkaconnect-w-auth.yml` template is used for Stage/Prod and relies on AWS MSK. It is configured with SASL/SCRAM and requires credentials to authenticate to the cluster. In order to authenticate, you will need a Kakfa user configured for the MSK cluster. See the **Managed Streaming for Apache Kafka (MSK) via App-Interface** section of the App Interface docs on how to add users. Note, the Inventory API Debezium Connector is also deployed as part of this manifest
 
-The `kafkaconnect-w-auth.yml` template is useful for adding to your deployment file for targeting stage/production environments where MSK is likely used and is configured with SASL/SCRAM. In order to authenticate, you will need a Kakfa user configured for the MSK cluster. See the **Managed Streaming for Apache Kafka (MSK) via App-Interface** section of the App Interface docs on how to add users.
+The final template, `kafka-connect-fedramp.yml`, is similar to the `kafkaconnect-w-auth.yml` deploy file but is designed for FedRAMP and leveraging a Strimzi Kafka cluster vs MSK.
 
 #### Using the Templates
 

--- a/deploy/sp-connectors/hbi-hosts-migration-connector.yml
+++ b/deploy/sp-connectors/hbi-hosts-migration-connector.yml
@@ -1,0 +1,81 @@
+# debezium v2.7
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: kafka-connectors
+objects:
+- apiVersion: kafka.strimzi.io/v1beta2
+  kind: KafkaConnector
+  metadata:
+    name: hbi-migration-connector
+    annotations:
+      strimzi.io/use-connector-resources: "true"
+    labels:
+      strimzi.io/cluster: ${KAFKA_CONNECT_INSTANCE}
+  spec:
+    state: stopped
+    class: io.debezium.connector.postgresql.PostgresConnector
+    tasksMax: ${{MAX_TASKS}}
+    config:
+      slot.name: debezium_hosts
+      signal.enabled.channels: "source,kafka"
+      signal.kafka.topic: "host-inventory.signal"
+      signal.kafka.bootstrap.servers: ${BOOTSTRAP_SERVERS}
+      signal.data.collection: "hbi.signal"
+      database.server.name: host-inventory-db
+      database.dbname: ${secrets:${DB_SECRET_NAME}:db.name}
+      database.hostname: ${secrets:${DB_SECRET_NAME}:db.host}
+      database.port: ${secrets:${DB_SECRET_NAME}:db.port}
+      database.user: ${secrets:${DB_SECRET_NAME}:db.user}
+      database.password: ${secrets:${DB_SECRET_NAME}:db.password}
+      topic.prefix: host-inventory
+      table.include.list: hbi.hosts_p.*
+      plugin.name: pgoutput
+      heartbeat.interval.ms: ${DEBEZIUM_HEARTBEAT_INTERVAL_MS}
+      heartbeat.action.query: ${DEBEZIUM_ACTION_QUERY}
+      topic.heartbeat.prefix: ${TOPIC_HEARTBEAT_PREFIX}
+      # Transform configurations
+      transforms: "route,unwrap,addOpHeader,addVerHeader,fieldFilter"
+      # Extract new record state (flatten envelope)
+      transforms.unwrap.type: "io.debezium.transforms.ExtractNewRecordState"
+      transforms.unwrap.drop.tombstones: "false"
+      # Route partition tables to logical table topic
+      transforms.route.type: "io.debezium.transforms.ByLogicalTableRouter"
+      transforms.route.topic.regex: "host-inventory\\.hbi\\.hosts.*"
+      transforms.route.topic.replacement: "host-inventory.hbi.hosts"
+      # Add static headers
+      transforms.addOpHeader.type: "org.apache.kafka.connect.transforms.InsertHeader"
+      transforms.addOpHeader.header: "operation"
+      transforms.addOpHeader.value.literal: "migration"
+      transforms.addVerHeader.type: "org.apache.kafka.connect.transforms.InsertHeader"
+      transforms.addVerHeader.header: "version"
+      transforms.addVerHeader.value.literal: "v1beta2"
+      transforms.fieldFilter.type: "org.apache.kafka.connect.transforms.ReplaceField$Value"
+      transforms.fieldFilter.include: "id,ansible_host,insights_id,satellite_id,subscription_manager_id,groups"
+parameters:
+- name: ENV_NAME
+  description: ClowdEnvironment name (ephemeral, stage, prod)
+  required: true
+- name: BOOTSTRAP_SERVERS
+  description: Kafka Bootstrap server(s) URL(s)
+  # value: "${ENV_NAME}-kafka-bootstrap:9092" # default for ephemeral
+  required: true
+- name: DB_SECRET_NAME
+  description: Name of the secret that contains database credentials
+  required: true
+- name: KAFKA_CONNECT_INSTANCE
+  value: kessel-kafka-connect
+  description: Name of the target Kafka Connect instance for Connector
+- name: MAX_TASKS
+  value: "1"
+  description: How many tasks the Kafka Connect instance can create to process this Connector's work
+- name: TOPIC_HEARTBEAT_PREFIX
+  value: debezium-heartbeat
+  description: Prefix for the connector heartbeat topic
+- name: DEBEZIUM_ACTION_QUERY
+  value: "SELECT pg_logical_emit_message(false, 'heartbeat', now()::varchar);"
+  description: Query action that runs for each heartbeat event
+- name: DEBEZIUM_HEARTBEAT_INTERVAL_MS
+  value: "300000"
+  description: The interval for the Debezium heartbeat in ms
+

--- a/deploy/sp-connectors/hbi-outbox-connector.yml
+++ b/deploy/sp-connectors/hbi-outbox-connector.yml
@@ -1,0 +1,59 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: kafka-connector
+objects:
+- apiVersion: kafka.strimzi.io/v1beta2
+  kind: KafkaConnector
+  metadata:
+    name: hbi-outbox-connector
+    labels:
+      strimzi.io/cluster: ${KAFKA_CONNECT_INSTANCE}
+  spec:
+    state: stopped
+    class: io.debezium.connector.postgresql.PostgresConnector
+    tasksMax: ${{MAX_TASKS}}
+    config:
+      slot.name: debezium_outbox
+      snapshot.mode: "no_data"
+      database.server.name: host-inventory-db
+      database.dbname: ${secrets:${DB_SECRET_NAME}:db.name}
+      database.hostname: ${secrets:${DB_SECRET_NAME}:db.host}
+      database.port: ${secrets:${DB_SECRET_NAME}:db.port}
+      database.user: ${secrets:${DB_SECRET_NAME}:db.user}
+      database.password: ${secrets:${DB_SECRET_NAME}:db.password}
+      topic.prefix: host-inventory
+      table.whitelist: hbi.outbox
+      table.include.list: hbi.outbox
+      transforms: outbox
+      transforms.outbox.type: io.debezium.transforms.outbox.EventRouter
+      transforms.outbox.table.fields.additional.placement: operation:header,version:header
+      transforms.outbox.table.expand.json.payload: true
+      value.converter: org.apache.kafka.connect.json.JsonConverter
+      plugin.name: pgoutput
+      heartbeat.interval.ms: ${DEBEZIUM_HEARTBEAT_INTERVAL_MS}
+      heartbeat.action.query: ${DEBEZIUM_ACTION_QUERY}
+      topic.heartbeat.prefix: ${TOPIC_HEARTBEAT_PREFIX}
+      poll.interval.ms: ${DEBEZIUM_POLL_INTERVAL_MS}
+parameters:
+- name: KAFKA_CONNECT_INSTANCE
+  value: kessel-kafka-connect
+  description: Name of the target Kafka Connect instance for Connector
+- name: DB_SECRET_NAME
+  description: Name of the secret that contains database credentials
+  required: true
+- name: MAX_TASKS
+  value: "1"
+  description: How many tasks the Kafka Connect instance can create to process this Connector's work
+- name: TOPIC_HEARTBEAT_PREFIX
+  value: debezium-heartbeat
+  description: Prefix for the connector heartbeat topic
+- name: DEBEZIUM_ACTION_QUERY
+  value: "SELECT pg_logical_emit_message(false, 'heartbeat', now()::varchar);"
+  description: Query action that runs for each heartbeat event
+- name: DEBEZIUM_HEARTBEAT_INTERVAL_MS
+  value: "300000"
+  description: The interval for the Debezium heartbeat in ms
+- name: DEBEZIUM_POLL_INTERVAL_MS
+  value: "250"
+  description: The interval for the Debezium batch processing


### PR DESCRIPTION
Adds HBI connectors to KKC for deployment in all envs + README update
* Ephemeral will be deployed via Insights Service Deployer script (PR coming to update)
* Stage/Prod will be deployed via app interface 
* All envs can use same connector CRs with proper param defs
* README updates to be more accurate with regards to KKC deploy files

Validation
Insights deployer script was updated to deploy these resources using my branch
```shell
create_hbi_connectors() {
  echo "Creating HBI debezium connectors..."
  NAMESPACE=env-$(oc project -q)
  oc process -f https://raw.githubusercontent.com/tonytheleg/kessel-kafka-connect/refs/heads/RHCLOUD-41797-add-hbi-connectors/deploy/sp-connectors/hbi-hosts-migration-connector.yml \
    -p KAFKA_CONNECT_INSTANCE="kessel-kafka-connect" \
    -p ENV_NAME="$NAMESPACE" \
    -p BOOTSTRAP_SERVERS="${NAMESPACE}-kafka-bootstrap:9092" \
    -p DB_SECRET_NAME="host-inventory-db" | oc apply -f -

  oc process -f https://raw.githubusercontent.com/tonytheleg/kessel-kafka-connect/refs/heads/RHCLOUD-41797-add-hbi-connectors/deploy/sp-connectors/hbi-outbox-connector.yml \
    -p KAFKA_CONNECT_INSTANCE="kessel-kafka-connect" \
    -p DB_SECRET_NAME="host-inventory-db" | oc apply -f -
}
```

Tested with 1000 hosts in hosts table, 1000 hosts in outbox
```
$ oc logs kessel-inventory-consumer-service-7769576b87-99xfl | grep "outbox.event" | tail -n 1
INFO ts=2025-08-14T14:56:01Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=consumed event from topic outbox.event.hbi.hosts, partition 0 at offset 999

$ oc logs kessel-inventory-consumer-service-7769576b87-99xfl | grep "host-inventory" | tail -n 1
INFO ts=2025-08-14T14:52:41Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=consumed event from topic host-inventory.hbi.hosts, partition 0 at offset 999

$ psql -h localhost -p 5432 -d kessel-inventory -U postgres --expanded -c "select count(*) from resources;"
-[ RECORD 1 ]
count | 2000

$ psql -h localhost -p 5432 -d kessel-inventory -U postgres --expanded -c "select count(*) from resources where consistency_token IS NOT NULL;"
-[ RECORD 1 ]
count | 2000
```