### PR TITLE
RHCLOUD-42062: add ca cert watchdog

### DIFF
--- a/deploy/kafka-connect-fedramp.yml
+++ b/deploy/kafka-connect-fedramp.yml
@@ -80,6 +80,51 @@ objects:
       heartbeat.action.query: ${DEBEZIUM_ACTION_QUERY}
       topic.heartbeat.prefix: ${TOPIC_HEARTBEAT_PREFIX}
       poll.interval.ms: ${DEBEZIUM_POLL_INTERVAL_MS}
+
+- apiVersion: batch/v1
+  kind: CronJob
+  metadata:
+    name: kakfa-ca-cert-watchdog
+  spec:
+    jobTemplate:
+      metadata:
+        name: kakfa-ca-cert-watchdog
+      spec:
+        successfulJobsHistoryLimit: 1
+        template:
+          spec:
+            containers:
+            - name: kakfa-ca-cert-watchdog
+              command:
+              - /bin/sh
+              - -c
+              - curl -o /tmp/ca-cert-checker.sh https://raw.githubusercontent.com/anatale/kessel-kafka-connect/refs/heads/main/scripts/heartbeat-fix.sh && chmod +x /tmp/heartbeat-fix.sh && /tmp/heartbeat-fix.sh
+              env:
+              - name: SA_CLIENT_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: kessel-sso-sa
+                    key: client-id
+              - name: SA_CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: kessel-sso-sa
+                    key: client-secret
+              - name: SSO_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: kessel-sso-sa
+                    key: url
+              image: registry.access.redhat.com/ubi9/ubi-minimal
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 384Mi
+            restartPolicy: Never
+    schedule: '@hourly'
 parameters:
   - name: BOOTSTRAP_SERVERS
     description: List of bootstrap servers (comma-separated list in 'hostname:port' notation)

--- a/deploy/kafka-connect-fedramp.yml
+++ b/deploy/kafka-connect-fedramp.yml
@@ -98,24 +98,15 @@ objects:
               command:
               - /bin/sh
               - -c
-              - curl -o /tmp/ca-cert-checker.sh https://raw.githubusercontent.com/anatale/kessel-kafka-connect/refs/heads/main/scripts/heartbeat-fix.sh && chmod +x /tmp/heartbeat-fix.sh && /tmp/heartbeat-fix.sh
+              - curl -o /tmp/ca-cert-checker.sh https://raw.githubusercontent.com/project-kessel/kessel-kafka-connect/refs/heads/main/scripts/ca-cert-checker.sh && chmod +x /tmp/ca-cert-checker.sh && /tmp/ca-cert-checker.sh
               env:
-              - name: SA_CLIENT_ID
-                valueFrom:
-                  secretKeyRef:
-                    name: kessel-sso-sa
-                    key: client-id
-              - name: SA_CLIENT_SECRET
-                valueFrom:
-                  secretKeyRef:
-                    name: kessel-sso-sa
-                    key: client-secret
-              - name: SSO_URL
-                valueFrom:
-                  secretKeyRef:
-                    name: kessel-sso-sa
-                    key: url
-              image: registry.access.redhat.com/ubi9/ubi-minimal
+              - name: WEBHOOK_URL
+                value: ${WEBHOOK_URL}
+              - name: ENV
+                value: ${ENV}
+              - name: KAFKA_BOOTSTRAP_SERVERS
+                value: ${BOOTSTRAP_SERVERS}
+              image: registry.access.redhat.com/ubi9/ubi
               resources:
                 limits:
                   cpu: 200m
@@ -124,7 +115,7 @@ objects:
                   cpu: 100m
                   memory: 384Mi
             restartPolicy: Never
-    schedule: '@hourly'
+    schedule: '@daily'
 parameters:
   - name: BOOTSTRAP_SERVERS
     description: List of bootstrap servers (comma-separated list in 'hostname:port' notation)
@@ -170,3 +161,7 @@ parameters:
   - name: DEBEZIUM_POLL_INTERVAL_MS
     value: "250"
     description: The interval for the Debezium batch processing
+  - name: WEBHOOK_URL
+    description: High side Google Chat Webhook URL for CA Cert Watcher alerts
+  - name: ENV
+    description: Environment where the service is running (int, stage, prod only)

--- a/scripts/ca-cert-checker.sh
+++ b/scripts/ca-cert-checker.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 readonly TEN_DAYS_IN_SECONDS=864000
-readonly TEST=9936000
-
 EXPIRING=false
 
 # Fetch the CA Cert
@@ -26,14 +24,8 @@ if [[ $? -ne 0 ]]; then
     EXPIRING=true
 fi
 
-# Expect to fail check
-openssl x509 -checkend $TEST -noout -in $CA_CERT
-if [[ $? -ne 0 ]]; then
-    EXPIRING=true
-fi
-
 if [[ "$EXPIRING" == "true" ]]; then
-    MESSAGE='{"text":"ALERT: IGNORE_TEST_ALERT Kafka Cluster CA Cert Expiring within 10 days
+    MESSAGE='{"text":"ALERT: Kafka Cluster CA Cert Expiring within 10 days
     Cluster Name: platform-mq-'"${ENV}"'
     Expiration Date: '"${CA_CERT_EXPIRATION}"'\n
     Alert: Kafka Cluster CA Cert expiration is approaching. The CA Cert will automatically be rotated. Services that require the CA cert for trust must be updated for the new CA Cert when available"}

--- a/scripts/ca-cert-checker.sh
+++ b/scripts/ca-cert-checker.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+readonly TEN_DAYS_IN_SECONDS=864000
+readonly TEST=9936000
+
+EXPIRING=false
+
+# Fetch the CA Cert
+pushd /tmp
+openssl s_client -showcerts -connect $KAFKA_BOOTSTRAP_SERVERS < /dev/null |
+   awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/{ if(/BEGIN CERTIFICATE/){a++}; out="cert"a".pem"; print >out}'
+
+for cert in *.pem; do
+    cnname=$(openssl x509 -noout -subject -in $cert | sed -nE 's/.*CN ?= ?(.*)/\1/; s/[ ,.*]/_/g; s/__/_/g; s/_-_/-/; s/^_//g;p')
+    if [[ "$cnname" = *"cluster-ca"* ]]; then
+        mv "${cert}" cluster-ca.crt
+    fi
+done
+
+CA_CERT=/tmp/cluster-ca.crt
+CA_CERT_EXPIRATION=$(openssl x509 -noout -enddate -in $CA_CERT | cut -d'=' -f 2)
+
+# 10 day check
+openssl x509 -checkend $TEN_DAYS_IN_SECONDS -noout -in $CA_CERT
+if [[ $? -ne 0 ]]; then
+    EXPIRING=true
+fi
+
+# Expect to fail check
+openssl x509 -checkend $TEST -noout -in $CA_CERT
+if [[ $? -ne 0 ]]; then
+    EXPIRING=true
+fi
+
+if [[ "$EXPIRING" == "true" ]]; then
+    MESSAGE='{"text":"ALERT: IGNORE_TEST_ALERT Kafka Cluster CA Cert Expiring within 10 days
+    Cluster Name: platform-mq-'"${ENV}"'
+    Expiration Date: '"${CA_CERT_EXPIRATION}"'\n
+    Alert: Kafka Cluster CA Cert expiration is approaching. The CA Cert will automatically be rotated. Services that require the CA cert for trust must be updated for the new CA Cert when available"}
+    '
+    RESPONSE=$(curl -X POST -H "Content-Type: application/json" "$WEBHOOK_URL" -d $"$MESSAGE")
+    if [[ $? -ne 0 ]]; then
+        echo "Failed to send alert: $RESPONSE"
+        exit 1
+    fi
+fi


### PR DESCRIPTION
For RHCLOUD-42062:
* adds cronjob to fedramp deployment to run a CA cert expiration check, and alert via app-sre-alerts gchat channel if the expiration is nearing (10 days)
* adds ca-cert-checker.sh script that facilitates the check