### PR TITLE
bumps limits to give some overhead

### DIFF
--- a/deploy/kafka-connect-fedramp.yml
+++ b/deploy/kafka-connect-fedramp.yml
@@ -39,7 +39,7 @@ objects:
     resources:
       limits:
         cpu: 1
-        memory: 2Gi
+        memory: 4Gi
       requests:
         cpu: 500m
         memory: 1Gi

--- a/deploy/kafkaconnect-w-auth.yml
+++ b/deploy/kafkaconnect-w-auth.yml
@@ -37,7 +37,7 @@ objects:
     resources:
       limits:
         cpu: 1
-        memory: 2Gi
+        memory: 4Gi
       requests:
         cpu: 500m
         memory: 1Gi


### PR DESCRIPTION
Ups the limit on Memory to 4GB to give some overhead, as we've seen memory issues on large migrations when errors occur. Comparing to prod platform-mq, they appear to be steady at 2GB usage