### PR TITLE
 RHCLOUD-47294: adds ephemeral deployment for KKC and key connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,39 +34,22 @@ make build-push-minimal
 ```
 
 ### Kafka Connect Deployment
+
 The KafkaConnect CR templates can be used to deploy a Kafka Connect cluster using the image built with the provided Dockerfile. There are 3 versions of the KafkaConnect CR: one with authentication, one without, and one for FedRAMP
 
-The `kafkaconnect-no-auth.yml` template is useful for Ephemeral testing, where the Clowder-provided Kafka cluster can be used for the Connect cluster and does not require any authentication. In ephemeral, by default Kessel Inventory API ships with Kessel Kafka Connect and can be deployed that way.
+The `kafkaconnect-ephem.yml` template is used for Ephemeral testing and can be deployed via bonfire. Note, the Clowder-provided Kafka cluster is used for the Connect cluster and does not require any authentication. The deployment also includes the Kessel Inventory outbox connector, and HBI outbox connector to simplify test deployments for service providers as well as the Mgmt Fabric teams.
 
-The `kafkaconnect-w-auth.yml` template is used for Stage/Prod and relies on AWS MSK. It is configured with SASL/SCRAM and requires credentials to authenticate to the cluster. In order to authenticate, you will need a Kakfa user configured for the MSK cluster. See the **Managed Streaming for Apache Kafka (MSK) via App-Interface** section of the App Interface docs on how to add users. Note, the Inventory API Debezium Connector is also deployed as part of this manifest
+```shell
+bonfire deploy kessel -C kessel-kafka-connect
+
+# Kessel Inventory also lists KKC as a dependency and can be deployed automatically while deploying Inventory API
+bonfire deploy kessel -C kessel-inventory
+```
+
+The `kafkaconnect-w-auth.yml` template is used for Stage/Prod and relies on AWS MSK. It is configured with SASL/SCRAM and requires credentials to authenticate to the cluster. In order to authenticate, you will need a Kakfa user configured for the MSK cluster. See the **Managed Streaming for Apache Kafka (MSK) via App-Interface** section of the App Interface docs on how to add users.
 
 The final template, `kafka-connect-fedramp.yml`, is similar to the `kafkaconnect-w-auth.yml` deploy file but is designed for FedRAMP and leveraging a Strimzi Kafka cluster vs MSK.
 
-#### Using the Templates
-
-To use the templates in your existing deployment template, copy the contents of the template to your existing template, and add the parameters to your existing parameter section in your deploy templates
-
-To use the templates directly:
-
-**Without Auth**
-```shell
-oc process --local -f deploy/kafkaconnect-no-auth.yml \
-    -p BOOTSTRAP_SERVERS=<Bootstrap Server Address> | oc apply -f -
-```
-
-> [!NOTE]
-> Any parameters defined in the template can be overwritten with `-p PARAM=VALUE` if desired.
->
-> Ephemeral Kafka clusters are not configured with Auth enabled, testing auth in Ephemeral would require a separate Kafka cluster.
-
-**With Auth**
-```shell
-oc process --local -f deploy/kafkaconnect-w-auth.yml \
-    -p BOOTSTRAP_SERVERS=<Bootstrap Server Address> \
-    -p KAFKA_USERNAME=<Kafka Username> \
-    -p KAFKA_USER_SECRET_NAME=<Name of Kafka Secret> \
-    -p KAFKA_USER_SECRET_KEY=<Key in Secret where password is defined> | oc apply -f -
-```
 
 #### Configuring Log Levels
 
@@ -78,14 +61,6 @@ Log levels for Kafka Connect and Debezium can be configured independently using 
 | `DEBEZIUM_LOG_LEVEL` | `INFO` | Log level for Debezium connectors |
 
 Valid values: `INFO`, `DEBUG`, `TRACE`
-
-Example with debug logging enabled:
-```shell
-oc process --local -f deploy/kafkaconnect-no-auth.yml \
-    -p BOOTSTRAP_SERVERS=<Bootstrap Server Address> \
-    -p CONNECT_LOG_LEVEL=DEBUG \
-    -p DEBEZIUM_LOG_LEVEL=INFO | oc apply -f -
-```
 
 #### Log Format with MDC
 

--- a/deploy/kafkaconnect-ephem.yml
+++ b/deploy/kafkaconnect-ephem.yml
@@ -171,8 +171,41 @@ objects:
       - pattern: kafka.connect<type=connect-coordinator-metrics><>(assigned-connectors|assigned-tasks)
         name: kafka_connect_coordinator_$1
         help: "Kafka Connect JMX metric assignment information"
-      type: GAUGE
-
+        type: GAUGE
+      - pattern : "kafka.connect<type=connect-worker-metrics>([^:]+):"
+        name: "kafka_connect_worker_metrics_$1"
+      - pattern : "kafka.connect<type=connect-metrics, client-id=([^:]+)><>([^:]+)"
+        name: "kafka_connect_metrics_$2"
+        labels:
+          client: "$1"
+      - pattern: "debezium.([^:]+)<type=connector-metrics, context=([^,]+), server=([^,]+), key=([^>]+)><>RowsScanned"
+        name: "debezium_metrics_RowsScanned"
+        labels:
+          plugin: "$1"
+          name: "$3"
+          context: "$2"
+          table: "$4"
+      - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^,]+), database=([^>]+)>([^:]+)"
+        name: "debezium_metrics_$6"
+        labels:
+          plugin: "$1"
+          name: "$2"
+          task: "$3"
+          context: "$4"
+          database: "$5"
+      - pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^>]+)>([^:]+)"
+        name: "debezium_metrics_$5"
+        labels:
+          plugin: "$1"
+          name: "$2"
+          task: "$3"
+          context: "$4"
+      - pattern: "debezium.([^:]+)<type=connector-metrics, context=([^,]+), server=([^>]+)>([^:]+)"
+        name: "debezium_metrics_$4"
+        labels:
+          plugin: "$1"
+          name: "$3"
+          context: "$2"
 - apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -189,7 +222,6 @@ objects:
       log4j.logger.org.apache.kafka.clients=${CONNECT_LOG_LEVEL}
       log4j.logger.io.debezium=${DEBEZIUM_LOG_LEVEL}
       log4j.logger.org.reflections=ERROR
-
 - apiVersion: kafka.strimzi.io/v1beta2
   kind: KafkaConnect
   metadata:
@@ -197,7 +229,7 @@ objects:
       strimzi.io/use-connector-resources: "true"
     name: kessel-kafka-connect
   spec:
-    bootstrapServers: ${BOOTSTRAP_SERVERS}
+    bootstrapServers: ${ENV_NAME}-kafka-bootstrap:9092
     metricsConfig:
       type: jmxPrometheusExporter
       valueFrom:
@@ -205,17 +237,17 @@ objects:
           key: metrics-config.yml
           name: kessel-kafka-connect-metrics
     config:
+      group.id: kessel-kafka-connect-cluster
       config.storage.replication.factor: ${CONFIG_STORAGE_REPLICATION_FACTOR}
       config.storage.topic: kessel-kafka-connect-cluster-configs
       connector.client.config.override.policy: All
-      group.id: kessel-kafka-connect-cluster
       offset.storage.replication.factor: ${OFFSET_STORAGE_REPLICATION_FACTOR}
       offset.storage.topic: kessel-kafka-connect-cluster-offsets
       status.storage.replication.factor: ${STATUS_STORAGE_REPLICATION_FACTOR}
       status.storage.topic: kessel-kafka-connect-cluster-status
       config.providers: secrets
       config.providers.secrets.class: io.strimzi.kafka.KubernetesSecretConfigProvider
-    image: ${KAFKA_CONNECT_IMAGE}
+    image: ${KAFKA_CONNECT_IMAGE}:${IMAGE_TAG}
     replicas: ${{CONNECT_REPLICAS}}
     resources:
       limits:
@@ -239,10 +271,79 @@ objects:
         volumeMounts:
         - name: log4j-config
           mountPath: /mnt/log4j
+      podDisruptionBudget:
+        maxUnavailable: 2
     version: ${VERSION}
+- apiVersion: kafka.strimzi.io/v1beta2
+  kind: KafkaConnector
+  metadata:
+    name: kessel-inventory-source-connector
+    labels:
+      strimzi.io/cluster: kessel-kafka-connect
+    annotations:
+      ${KCTR_ANNOTATION_KEY}: ${KCTR_ANNOTATION_VAL}
+  spec:
+    class: io.debezium.connector.postgresql.PostgresConnector
+    tasksMax: 1 # source connector only supports 1 task
+    config:
+      slot.name: inventory_api_debezium
+      snapshot.mode: no_data
+      database.server.name: kessel-inventory-db
+      database.dbname: ${secrets:kessel-inventory-db:db.name}
+      database.hostname: ${secrets:kessel-inventory-db:db.host}
+      database.port: ${secrets:kessel-inventory-db:db.port}
+      database.user: ${secrets:kessel-inventory-db:db.user}
+      database.password: ${secrets:kessel-inventory-db:db.password}
+      topic.prefix: kessel-inventory
+      table.exclude.list: ".*"
+      message.prefix.include.list: "kessel.tuples,kessel.resources"
+      transforms: "decode,outbox"
+      transforms.decode.type: io.debezium.connector.postgresql.transforms.DecodeLogicalDecodingMessageContent
+      transforms.outbox.type: io.debezium.transforms.outbox.EventRouter
+      transforms.outbox.table.fields.additional.placement: operation:header, txid:header
+      transforms.outbox.table.expand.json.payload: true
+      value.converter: org.apache.kafka.connect.json.JsonConverter
+      plugin.name: pgoutput
+      heartbeat.interval.ms: ${DEBEZIUM_HEARTBEAT_INTERVAL_MS}
+      heartbeat.action.query: ${DEBEZIUM_ACTION_QUERY}
+      topic.heartbeat.prefix: ${TOPIC_HEARTBEAT_PREFIX}
+      poll.interval.ms: ${DEBEZIUM_POLL_INTERVAL_MS}
+### SP Outbox Connectors
+- apiVersion: kafka.strimzi.io/v1beta2
+  kind: KafkaConnector
+  metadata:
+    name: hbi-outbox-connector
+    labels:
+      strimzi.io/cluster: kessel-kafka-connect
+  spec:
+    state: running
+    class: io.debezium.connector.postgresql.PostgresConnector
+    tasksMax: 1 # source connector only supports 1 task
+    config:
+      slot.name: debezium_outbox
+      snapshot.mode: "no_data"
+      database.server.name: host-inventory-db
+      database.dbname: ${secrets:${HBI_DB_SECRET_NAME}:db.name}
+      database.hostname: ${secrets:${HBI_DB_SECRET_NAME}:db.host}
+      database.port: ${secrets:${HBI_DB_SECRET_NAME}:db.port}
+      database.user: ${secrets:${HBI_DB_SECRET_NAME}:db.user}
+      database.password: ${secrets:${HBI_DB_SECRET_NAME}:db.password}
+      topic.prefix: host-inventory
+      table.whitelist: hbi.outbox
+      table.include.list: hbi.outbox
+      transforms: outbox
+      transforms.outbox.type: io.debezium.transforms.outbox.EventRouter
+      transforms.outbox.table.fields.additional.placement: operation:header,version:header
+      transforms.outbox.table.expand.json.payload: true
+      value.converter: org.apache.kafka.connect.json.JsonConverter
+      plugin.name: pgoutput
+      heartbeat.interval.ms: ${DEBEZIUM_HEARTBEAT_INTERVAL_MS}
+      heartbeat.action.query: ${DEBEZIUM_ACTION_QUERY}
+      topic.heartbeat.prefix: ${TOPIC_HEARTBEAT_PREFIX}
+      poll.interval.ms: ${DEBEZIUM_POLL_INTERVAL_MS}
 parameters:
-  - name: BOOTSTRAP_SERVERS
-    description: List of bootstrap servers (comma-separated list in 'hostname:port' notation)
+  - description: ClowdEnvironment name (ephemeral, stage, prod)
+    name: ENV_NAME
     required: true
   - name: CONFIG_STORAGE_REPLICATION_FACTOR
     description: Replication factor for the topic where connector configurations are stored
@@ -256,12 +357,22 @@ parameters:
   - name: KAFKA_CONNECT_IMAGE
     value: quay.io/redhat-services-prod/project-kessel-tenant/kessel-kafka-connect
     description: Container image name for the connect cluster pods
+  - name: IMAGE_TAG
+    required: true
+    value: latest
+    description: Image tag for the connect image
   - name: CONNECT_REPLICAS
     description: Number of replicas in the connect cluster
     value: "1"
   - name: VERSION
     description: Kafka Connect version to use (should match the Kafka version of cluster and connect base image)
     value: "3.9.0"
+  - name: KCTR_ANNOTATION_KEY
+    description: Allows setting a single annotation key for connector management, such as restarting a task. Defaults to an ignored value
+    value: "kessel/no-op"
+  - name: KCTR_ANNOTATION_VAL
+    description: Allows setting a single annotation value for connector management, such as restarting a task. Defaults to an ignored value
+    value: ""
   - name: KKC_CPU_LIMIT
     value: "1000m"
     description: Sets the CPU limit for Kessel Kafka Connect pod
@@ -280,3 +391,18 @@ parameters:
   - name: DEBEZIUM_LOG_LEVEL
     value: "INFO"
     description: Log level for Debezium connectors (INFO, DEBUG, TRACE)
+  - name: HBI_DB_SECRET_NAME
+    description: Name of the secret that contains database credentials
+    value: host-inventory-db
+  - name: TOPIC_HEARTBEAT_PREFIX
+    value: debezium-heartbeat
+    description: Prefix for the connector heartbeat topic
+  - name: DEBEZIUM_ACTION_QUERY
+    value: "SELECT pg_logical_emit_message(false, 'heartbeat', now()::varchar);"
+    description: Query action that runs for each heartbeat event
+  - name: DEBEZIUM_HEARTBEAT_INTERVAL_MS
+    value: "300000"
+    description: The interval for the Debezium heartbeat in ms
+  - name: DEBEZIUM_POLL_INTERVAL_MS
+    value: "250"
+    description: The interval for the Debezium batch processing


### PR DESCRIPTION
### Changes

Updates to support ephemeral deployment using bonfire and help deprecate insights service deployer:
* renames no-auth deployment to kafkaconnect-ephem.yml
* updates Kafka Connect deployment based on existing ephemeral deployment in Inventory API (which will be removed)
* updates metrics config map to match existing ephemeral deployment in Inventory API (which will be removed)
* adds inventory api source connector and hbi outbox connector to reduce dependency on insights service deployer tool
* updates params for all required settings
* updates README for changes

### Why

Service provider connectors are currently handled by the insights service deployer script which means they are not deployable via bonfire. By adding an ephemeral deployment that includes the connectors, this reduces dependency on the script and any post-bonfire ad-hoc steps. Currently KKC and the Inventory API source connector are deployed via Kessel Invenory's ephemeral deployment. They will be removed once KKC ephem target is available to use via App Interface.

### Validation

```shell
$ bonfire deploy kessel -C kessel-kafka-connect 
2026-04-27 09:55:34 [    INFO] [          MainThread] running (pid 526478): oc project -q 
2026-04-27 09:55:34 [    INFO] [          pid-526478]  |stdout| ephemeral-ih1n8g
2026-04-27 09:55:34 [    INFO] [          MainThread] attempting to use current namespace from oc/kubectl context...
2026-04-27 09:55:34 [    INFO] [          MainThread] current namespace could not be used (not reserved, expired, or not owned), reserving a new one
---TRUNCATED---
2026-04-27 09:55:43 [    INFO] [          MainThread] running (pid 526867): oc apply -f - -n ephemeral-ltnbdj 
2026-04-27 09:55:43 [    INFO] [          pid-526867]  |stdout| configmap/kessel-kafka-connect-metrics created
2026-04-27 09:55:44 [    INFO] [          pid-526867]  |stdout| configmap/kessel-kafka-connect-log4j created
2026-04-27 09:55:44 [    INFO] [          pid-526867]  |stdout| kafkaconnect.kafka.strimzi.io/kessel-kafka-connect created
2026-04-27 09:55:44 [    INFO] [          pid-526867]  |stdout| kafkaconnector.kafka.strimzi.io/kessel-inventory-source-connector created
2026-04-27 09:55:44 [    INFO] [          pid-526867]  |stdout| kafkaconnector.kafka.strimzi.io/hbi-outbox-connector created
---TRUNCATED---
2026-04-27 09:57:09 [    INFO] [          MainThread] all resources being monitored reached 'ready' state
2026-04-27 09:57:09 [    INFO] [          MainThread] successfully deployed to namespace ephemeral-ltnbdj
2026-04-27 09:57:09 [    INFO] [          MainThread] namespace url: https://console-openshift-console.apps.crc-eph.r9lp.p1.openshiftapps.com/k8s/cluster/projects/ephemeral-ltnbdj
2026-04-27 09:57:09 [    INFO] [          MainThread] resource usage dashboard for namespace 'ephemeral-ltnbdj': https://grafana.app-sre.devshift.net/d/jRY7KLnVz?var-namespace=ephemeral-ltnbdj

$ oc get kc kessel-kafka-connect 
NAME                   DESIRED REPLICAS   READY
kessel-kafka-connect   1                  True

$ oc get pod kessel-kafka-connect-connect-0 
NAME                             READY   STATUS    RESTARTS   AGE
kessel-kafka-connect-connect-0   1/1     Running   0          3m41s

# NOTE: connectors are not ready because neither Inventory or HBI are deployed but they do not impact KKC function
$ oc get kctr
NAME                                CLUSTER                CONNECTOR CLASS                                      MAX TASKS   READY
hbi-outbox-connector                kessel-kafka-connect   io.debezium.connector.postgresql.PostgresConnector   1           
kessel-inventory-source-connector   kessel-kafka-connect   io.debezium.connector.postgresql.PostgresConnector   1           
```