### PR TITLE
RHCLOUD-48946: adds ClowdAppRef to allow defining KKC as dependency in ClowdApps

### DIFF
--- a/.tekton/kessel-kafka-connect-fedramp-pull-request.yaml
+++ b/.tekton/kessel-kafka-connect-fedramp-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: "false"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: kessel-kafka-connect

--- a/.tekton/kessel-kafka-connect-fedramp-push.yaml
+++ b/.tekton/kessel-kafka-connect-fedramp-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: "false"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: kessel-kafka-connect

--- a/deploy/kafkaconnect-ephem.yml
+++ b/deploy/kafkaconnect-ephem.yml
@@ -3,6 +3,12 @@ kind: Template
 metadata:
   name: kafka-connect-template
 objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdAppRef
+  metadata:
+    name: kessel-kafkaconnect
+  spec:
+    envName: ${ENV_NAME}
 - apiVersion: v1
   kind: ConfigMap
   metadata:


### PR DESCRIPTION
Background:
Related ClowdApp config: https://github.com/project-kessel/inventory-api/blob/main/deploy/kessel-inventory-ephem.yaml#L208-L211

When kessel-inventory lists kessel-kafkaconnect as an optionalDependency, bonfire deploys it alongside inventory in direct ephemeral deployments. But the dependency isn't transitive. When another app like host-inventory lists kessel-inventory as a dependency, bonfire walks the dependencies list recursively but skips optionalDependencies (with default "hybrid" setting). So kessel-relations gets pulled in, but kessel-kafkaconnect does not. We are trying to avoid services integrating with kessel having to explicitly set `--optional-deps-method all` with bonfire and avoid any unknown transitive behaviors that may also occur; they shouldn't have to worry about optional deps, our service should properly define its deps for them.

We can't simply move kessel-kafkaconnect to dependencies because Clowder's dependency resolver only checks for two resource types: ClowdApp and ClowdAppRef. Since kessel-kafkaconnect is a Strimzi KafkaConnect resource (not a ClowdApp), Clowder would fail to find it, return a MissingDependencies error, and block reconciliation indefinitely.

A ClowdAppRef should help solve this without Clowder managing the underlying workload. By adding a minimal ClowdAppRef named kessel-kafkaconnect to the kafkaconnect deploy template, Clowder's existence check passes and reconciliation succeeds. With the ClowdAppRef in place, kessel-kafkaconnect can be moved from optionalDependencies to dependencies in the inventory ClowdApp spec therefore solving the issue without requiring teams to deviate from default bonfire commands already defined in their deployments, CI/CD, and testing. 

~Currently we do not have permissions to create ClowdAppRef’s in ephemeral, and Clowder does not ship with any role that we could leverage via rolebinding so one would need to be created. A PR is pending in app interface, until that is merged, this PR cannot be merged or it will fail to deploy when using bonfire. See Jira for PR link.~

Permissions to ClowdAppRef's have been added and ive tested that the dependencies setup is working with ClowdAppRef

```shell
# tested using the following bonfire command: bonfire deploy --source=appsre --ref-env insights-production --timeout 900 --optional-deps-method hybrid --frontends false host-inventory

$ oc get app kessel-inventory -o yaml | grep -A 2 dependencies:
  dependencies:
  - kessel-relations
  - kessel-kafkaconnect

$ oc get app | grep kessel
kessel-inventory   2       2         env-ephemeral-pnizxf   5m56s
kessel-relations   1       1         env-ephemeral-pnizxf   5m54s

$ oc get clowdappref
NAME                  READY   ENV                    AGE
kessel-kafkaconnect           env-ephemeral-pnizxf   6m4s

$ oc get pods | grep kessel
kessel-inventory-api-cd6695d54-6vdcd                      2/2     Running     0             8m43s
kessel-inventory-db-695b797d5f-cjx6v                      1/1     Running     0             9m2s
kessel-kafka-connect-connect-0                            1/1     Running     0             9m11s
kessel-relations-api-6fd669658-67jwj                      2/2     Running     0             8m46s
kessel-spicedb-postgres-54bf48c8-zrg22                    1/1     Running     0             9m12s
kessel-spicedb-spicedb-66794d5b5c-8cw87                   1/1     Running     0             8m51s
```

Also this PR disables FedRAMP builds as they are not in use and wasting resources