### PR TITLE
NOJIRA-12345: reverts change to disable fedramp pipelines

### DIFF
--- a/.tekton/kessel-kafka-connect-fedramp-pull-request.yaml
+++ b/.tekton/kessel-kafka-connect-fedramp-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: "false"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: kessel-kafka-connect

--- a/.tekton/kessel-kafka-connect-fedramp-push.yaml
+++ b/.tekton/kessel-kafka-connect-fedramp-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: kessel-kafka-connect

--- a/.tekton/kessel-kafka-connect-fedramp-push.yaml
+++ b/.tekton/kessel-kafka-connect-fedramp-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: "false"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: kessel-kafka-connect


### PR DESCRIPTION
Disabling the fedramp pipeline may be breaking builds

✕ [Violation] builtin.image.accessible
  ImageRef: quay.io/redhat-user-workloads/project-kessel-tenant/kessel-kafka-connect@sha256:65c769638fc1246a16a3240f3d29543a45c6d56e981734aa01186cd9670183d2
  Reason: Image URL is not accessible: HEAD
  https://quay.io/v2/redhat-user-workloads/project-kessel-tenant/kessel-kafka-connect/manifests/sha256:65c769638fc1246a16a3240f3d29543a45c6d56e981734aa01186cd9670183d2:
  unexpected status code 404 Not Found (HEAD responses have no body, use GET for details)
  Title: Image URL is accessible
  Description: The image URL is available and accessible.

Components:
- Name: kessel-kafka-connect
  ImageRef: quay.io/redhat-user-workloads/project-kessel-tenant/kessel-kafka-connect@sha256:b67c1a30e2ce1c58523412ae69996076e23a4dfbbc5502ecc8713eac94f59b94
  Violations: 0, Warnings: 10, Successes: 132

- Name: kessel-kafka-connect-fedramp
  ImageRef: quay.io/redhat-user-workloads/project-kessel-tenant/kessel-kafka-connect@sha256:65c769638fc1246a16a3240f3d29543a45c6d56e981734aa01186cd9670183d2
  Violations: 1, Warnings: 0, Successes: 0

Results:
✕ [Violation] builtin.image.accessible
  ImageRef: quay.io/redhat-user-workloads/project-kessel-tenant/kessel-kafka-connect@sha256:65c769638fc1246a16a3240f3d29543a45c6d56e981734aa01186cd9670183d2
  Reason: Image URL is not accessible: HEAD
  https://quay.io/v2/redhat-user-workloads/project-kessel-tenant/kessel-kafka-connect/manifests/sha256:65c769638fc1246a16a3240f3d29543a45c6d56e981734aa01186cd9670183d2:
  unexpected status code 404 Not Found (HEAD responses have no body, use GET for details)
  Title: Image URL is accessible
  Description: The image URL is available and accessible.

Reverting the change that disabled them